### PR TITLE
chore: use Xcode 16.4 for xcframework in github action

### DIFF
--- a/.github/workflows/posemesh-sdk.yml
+++ b/.github/workflows/posemesh-sdk.yml
@@ -146,8 +146,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup LLVM 18 clang
-        run: echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+      - name: Switch to Xcode 16.4
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.4.app
+          sudo xcodebuild -version
 
       - name: Download all Frameworks
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Already updated the other github action step for the framework builds to newest xcode.
This PR updates also the xcframework step which bundles all apple platforms into one.