### PR TITLE
feat: add robot machine authentication

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3873,7 +3873,7 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "posemesh-compute-node"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/compute-node-runner-api/examples/hello-runner/.env.robot.example
+++ b/core/compute-node-runner-api/examples/hello-runner/.env.robot.example
@@ -1,6 +1,9 @@
 # Copy this file to .env and replace the placeholders before starting the
 # explicit robot runner. Never commit the populated .env file.
+# Configure exactly one credential source. Enrollment wrappers should write the
+# opaque credential to a persistent secret volume and use the file option.
 ROBOT_REGISTRATION_CREDENTIALS=<opaque-credentials-returned-once-by-dds>
+# ROBOT_REGISTRATION_CREDENTIALS_FILE=/run/secrets/posemesh/robot-credentials
 DDS_BASE_URL=http://127.0.0.1:8080
 DMS_BASE_URL=http://127.0.0.1:8081/v1
 LOG_FORMAT=text

--- a/core/compute-node-runner-api/examples/hello-runner/.env.robot.example
+++ b/core/compute-node-runner-api/examples/hello-runner/.env.robot.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and replace the placeholders before starting the
+# explicit robot runner. Never commit the populated .env file.
+ROBOT_REGISTRATION_CREDENTIALS=<opaque-credentials-returned-once-by-dds>
+DDS_BASE_URL=http://127.0.0.1:8080
+DMS_BASE_URL=http://127.0.0.1:8081/v1
+LOG_FORMAT=text

--- a/core/compute-node-runner-api/examples/hello-runner/Cargo.toml
+++ b/core/compute-node-runner-api/examples/hello-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "posemesh-hello-runner"
 version = "0.1.0"
 edition = "2021"
 publish = false
+default-run = "posemesh-hello-runner"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/core/compute-node-runner-api/examples/hello-runner/src/bin/posemesh-robot-hello-runner.rs
+++ b/core/compute-node-runner-api/examples/hello-runner/src/bin/posemesh-robot-hello-runner.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use posemesh_compute_node::engine::RunnerRegistry;
+use posemesh_compute_node::config::RobotNodeConfig;
+use posemesh_compute_node::engine::{run_robot_node, RunnerRegistry};
 use posemesh_compute_node::telemetry;
 use posemesh_hello_runner::HelloRunner;
 use tracing::info;
@@ -12,15 +13,13 @@ async fn main() -> Result<()> {
 
     telemetry::init_from_env()?;
 
-    let cfg = posemesh_compute_node::config::NodeConfig::from_env()?;
+    let cfg = RobotNodeConfig::from_env()?;
 
     let registry = RunnerRegistry::new().register(HelloRunner);
     let capabilities = registry.capabilities();
+    info!(?capabilities, "robot hello runner registered capabilities");
 
-    posemesh_compute_node::dds::register::spawn_registration_if_configured(&cfg, &capabilities)?;
-    info!(?capabilities, "hello runner registered capabilities");
-
-    posemesh_compute_node::engine::run_node(cfg, registry).await?;
+    run_robot_node(cfg, registry).await?;
 
     Ok(())
 }

--- a/core/compute-node-runner-api/examples/hello-runner/src/lib.rs
+++ b/core/compute-node-runner-api/examples/hello-runner/src/lib.rs
@@ -1,0 +1,84 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use posemesh_compute_node::telemetry;
+use posemesh_compute_node_runner_api as compute_runner_api;
+use serde_json::json;
+use std::path::Path;
+use tracing::info;
+use uuid::Uuid;
+
+pub struct HelloRunner;
+
+#[async_trait]
+impl compute_runner_api::Runner for HelloRunner {
+    fn capability(&self) -> &'static str {
+        "/examples/hello/v1"
+    }
+
+    async fn run(&self, ctx: compute_runner_api::TaskCtx<'_>) -> Result<()> {
+        let lease = ctx.lease;
+
+        // Attach common task identifiers to every tracing event emitted in this task.
+        let task_span = telemetry::task_span(
+            lease.task.id,
+            lease.task.job_id.unwrap_or_else(Uuid::nil),
+            &lease.task.capability,
+            lease.domain_id.unwrap_or_else(Uuid::nil),
+        );
+        let _span_guard = task_span.enter();
+
+        const FILE_NAME: &str = "posemesh-multipart-test.bin";
+        let file_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(FILE_NAME);
+
+        ctx.ctrl
+            .progress(json!({ "status": "started", "file": FILE_NAME }))
+            .await?;
+
+        let file_size = tokio::fs::metadata(&file_path)
+            .await
+            .with_context(|| format!("stat {}", file_path.display()))?
+            .len();
+
+        ctx.ctrl
+            .log_event(json!({
+                "level": "info",
+                "message": "uploading file",
+                "task_id": lease.task.id,
+                "job_id": lease.task.job_id,
+                "path": file_path.to_string_lossy(),
+                "rel_path": FILE_NAME,
+                "bytes": file_size,
+            }))
+            .await?;
+
+        info!(
+            task_id = %lease.task.id,
+            job_id = ?lease.task.job_id,
+            path = %file_path.display(),
+            rel_path = FILE_NAME,
+            bytes = file_size,
+            "uploading file"
+        );
+
+        ctx.output
+            .put_file(FILE_NAME, &file_path)
+            .await
+            .with_context(|| format!("upload {}", file_path.display()))?;
+
+        ctx.ctrl
+            .progress(json!({
+                "status": "finished",
+                "rel_path": FILE_NAME,
+                "bytes_written": file_size
+            }))
+            .await?;
+
+        info!(
+            bytes_written = file_size,
+            rel_path = FILE_NAME,
+            "hello-runner finished"
+        );
+
+        Ok(())
+    }
+}

--- a/core/compute-node/Cargo.toml
+++ b/core/compute-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posemesh-compute-node"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT"
 description = "Posemesh compute node engine: config, DDS/DMS, heartbeat, storage (no persistence)."

--- a/core/compute-node/README.md
+++ b/core/compute-node/README.md
@@ -4,7 +4,9 @@
 the binary crate (`bin`) wires together. The crate is responsible for
 loading configuration, authenticating with DDS, polling DMS for work, managing
 sessions, streaming heartbeats, and brokering storage traffic to the domain
-server on behalf of capability-specific runners.
+server on behalf of capability-specific runners. Legacy SIWE and robot machine
+authentication use separate, explicit entrypoints while sharing the task
+engine.
 
 ## Responsibilities
 - Environment-driven configuration (`config`) with typed accessors and sane
@@ -13,7 +15,8 @@ server on behalf of capability-specific runners.
   exposes helper spans.
 - DDS registration helpers (`dds::register`) and the in-memory persistence stub
   used by legacy registration callbacks (`dds::persist`).
-- Authentication state machine for SIWE after registration (`auth` module).
+- Authentication state machines for SIWE after registration and opt-in robot
+  machine authentication (`auth` module).
 - DMS HTTP client (`dms::client`) plus request/response data contracts.
 - Storage façade that turns leases into runner-facing input/output ports
   (`storage::{input, output, client, token}`).
@@ -25,14 +28,15 @@ server on behalf of capability-specific runners.
 
 ## Runtime flow (engine overview)
 1. `telemetry::init_from_env()` installs logging based on `LOG_FORMAT`.
-2. `NodeConfig::from_env()` loads operational settings. The node currently
-   requires DDS configuration (see below) because SIWE tokens are mandatory.
+2. The selected entrypoint loads either `NodeConfig` for legacy SIWE or the
+   separate `RobotNodeConfig` for robot machine authentication.
 3. Runners are registered in a `RunnerRegistry`; the binary decides which
    capabilities to advertise.
-4. `dds::register::spawn_registration_if_configured()` starts the outbound
-   SIWE-based registration bootstrap/recovery loop, and
-   `auth::SiweAfterRegistration` waits for a successful registration before
-   requesting access tokens.
+4. The legacy entrypoint starts
+   `dds::register::spawn_registration_if_configured()` and then
+   `auth::SiweAfterRegistration`. The robot entrypoint registers directly with
+   its opaque DDS-issued credential and never starts legacy registration or
+   falls back to SIWE.
 5. The main `run_node` loop obtains an access token from DDS, builds a DMS
    client, leases tasks, initializes session state, and dispatches to the
    correct runner via `RunnerRegistry::run_for_lease`.
@@ -44,18 +48,23 @@ server on behalf of capability-specific runners.
 
 ## Configuration surface
 
-Required environment variables:
+Required environment variables for the legacy SIWE entrypoint:
 - `REG_SECRET` — shared secret issued by DDS during provisioning.
 - `SECP256K1_PRIVHEX` — 32-byte hex-encoded private key used to sign SIWE
   messages.
+
+Required environment variable for the explicit robot entrypoint:
+- `ROBOT_REGISTRATION_CREDENTIALS` — the complete opaque credential returned
+  once when DDS provisions or rotates the robot. Do not decode, split, log, or
+  commit it.
 
 Optional environment variables:
 - `DMS_BASE_URL` (default `https://dms.auki.network/v1`) — base URL of the DMS
   REST API.
 - `DDS_BASE_URL` (default `https://dds.auki.network`) — base URL of the DDS API
-  (used for SIWE authentication).
-- `REQUEST_TIMEOUT_SECS` (default `60`) — per-request timeout applied to DMS
-  calls.
+  used by the selected authentication flow.
+- `REQUEST_TIMEOUT_SECS` (default `60`) — per-request timeout applied to DDS
+  authentication and DMS calls.
 - `NODE_VERSION` (default crate version) — optional override for the advertised
   node version.
 - `HEARTBEAT_JITTER_MS` (default `250`) — backoff applied when coalescing
@@ -64,23 +73,55 @@ Optional environment variables:
   fraction of the lease TTL after which the engine schedules the next heartbeat.
 - `POLL_BACKOFF_MS_MIN` / `POLL_BACKOFF_MS_MAX` (defaults `1000` / `30000`) —
   jitter range used between idle lease polls.
-- `TOKEN_SAFETY_RATIO` (default `0.75`) — SIWE token renewal threshold.
+- `TOKEN_SAFETY_RATIO` (default `0.75`) — access-token renewal threshold.
 - `TOKEN_REAUTH_MAX_RETRIES` (default `3`) — retries before bailing on token
   refresh.
 - `TOKEN_REAUTH_JITTER_MS` (default `500`) — jitter applied between retries.
-- `REGISTER_INTERVAL_SECS` (default `120`) — cooldown between registration
-  attempts while the node is not yet registered or is recovering.
-- `REGISTER_MAX_RETRY` (default `-1`, meaning infinite retries) — retry cap for
-  transient registration failures before falling back to the regular cooldown.
+- `REGISTER_INTERVAL_SECS` (legacy SIWE only; default `120`) — cooldown between
+  registration attempts while the node is not yet registered or is recovering.
+- `REGISTER_MAX_RETRY` (legacy SIWE only; default `-1`, meaning infinite
+  retries) — retry cap for transient registration failures before falling back
+  to the regular cooldown.
 - `MAX_CONCURRENCY` (default `1`) — staging knob for future multi-runner
   concurrency.
 - `LOG_FORMAT` (default `json`) — set to `text` for pretty console logs.
 - `ENABLE_NOOP` (default `false`) — when true the binary registers noop runners.
 - `NOOP_SLEEP_SECS` (default `5`) — noop runner sleep duration.
 
+## Hello runner entrypoints
+
+The existing command remains the default and continues to use SIWE:
+
+```sh
+cd core
+cargo run -p posemesh-hello-runner
+```
+
+Robot mode is deliberately a different binary. From the `core` workspace, copy
+the placeholder without overwriting any existing legacy SIWE `.env`, insert the
+one-time credential returned by DDS, and invoke that binary by name:
+
+```sh
+cp -n compute-node-runner-api/examples/hello-runner/.env.robot.example \
+  compute-node-runner-api/examples/hello-runner/.env
+cargo run -p posemesh-hello-runner --bin posemesh-robot-hello-runner
+```
+
+The example advertises `/examples/hello/v1`. A disposable local DDS must have
+that capability catalogued with `public_url_required = false` and the robot
+must be provisioned with the same capability. The example does not add or
+enable a production DDS capability.
+
+Choosing a binary is the authentication-mode switch. Supplying
+`ROBOT_REGISTRATION_CREDENTIALS` to the default SIWE binary does not select
+robot mode, and the robot binary does not read `REG_SECRET` or
+`SECP256K1_PRIVHEX`.
+
 ## Notable modules
 - `auth::siwe_after_registration` — waits for DDS registration, then spins up
   the SIWE token manager and refresh loop.
+- `auth::robot` — registers and renews robot machine credentials without a
+  wallet, private key, or SIWE fallback.
 - `dds::register` — normalizes versions (stripping leading `v`), validates the
   secp256k1 key, and launches the registration task using
   `posemesh-node-registration`. Once acquired, registration is parked until the

--- a/core/compute-node/README.md
+++ b/core/compute-node/README.md
@@ -53,10 +53,17 @@ Required environment variables for the legacy SIWE entrypoint:
 - `SECP256K1_PRIVHEX` — 32-byte hex-encoded private key used to sign SIWE
   messages.
 
-Required environment variable for the explicit robot entrypoint:
+Required credential source for the explicit robot entrypoint (configure exactly
+one):
 - `ROBOT_REGISTRATION_CREDENTIALS` — the complete opaque credential returned
-  once when DDS provisions or rotates the robot. Do not decode, split, log, or
-  commit it.
+  once when DDS provisions or rotates the robot.
+- `ROBOT_REGISTRATION_CREDENTIALS_FILE` — path to a file containing that opaque
+  credential. This is the preferred handoff from an enrollment wrapper or
+  container init step using a persistent secret volume.
+
+Do not decode, split, log, or commit the credential. The file loader trims a
+trailing newline and fails closed when the path is unreadable or the file is
+empty. Updating the file requires restarting the compute node.
 
 Optional environment variables:
 - `DMS_BASE_URL` (default `https://dms.auki.network/v1`) — base URL of the DMS
@@ -112,10 +119,9 @@ that capability catalogued with `public_url_required = false` and the robot
 must be provisioned with the same capability. The example does not add or
 enable a production DDS capability.
 
-Choosing a binary is the authentication-mode switch. Supplying
-`ROBOT_REGISTRATION_CREDENTIALS` to the default SIWE binary does not select
-robot mode, and the robot binary does not read `REG_SECRET` or
-`SECP256K1_PRIVHEX`.
+Choosing a binary is the authentication-mode switch. Supplying either robot
+credential source to the default SIWE binary does not select robot mode, and
+the robot binary does not read `REG_SECRET` or `SECP256K1_PRIVHEX`.
 
 ## Notable modules
 - `auth::siwe_after_registration` — waits for DDS registration, then spins up

--- a/core/compute-node/src/auth/mod.rs
+++ b/core/compute-node/src/auth/mod.rs
@@ -1,7 +1,9 @@
+pub mod robot;
 pub mod siwe;
 pub mod siwe_after_registration;
 pub mod token_manager;
 
+pub use robot::{RobotHandle, RobotMachineAuth};
 pub use siwe::{AccessBundle, SiweError};
 pub use siwe_after_registration::{SiweAfterRegistration, SiweHandle};
 pub use token_manager::{

--- a/core/compute-node/src/auth/robot.rs
+++ b/core/compute-node/src/auth/robot.rs
@@ -1,0 +1,268 @@
+use super::siwe::{AccessBundle, SiweError};
+use super::token_manager::{
+    AccessAuthenticator, SystemClock, TokenManager, TokenManagerConfig, TokenProvider,
+    TokenProviderError,
+};
+use crate::config::RobotNodeConfig;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use reqwest::{Client, Response};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use url::Url;
+use uuid::Uuid;
+
+const REGISTER_PATH: &str = "/internal/v1/robots/register";
+const VERIFY_PATH: &str = "/internal/v1/auth/robot/verify";
+
+type ManagerCell = Arc<Mutex<Option<Arc<RobotTokenManager>>>>;
+type RobotTokenManager = TokenManager<RobotAuthenticator, SystemClock>;
+
+#[derive(Serialize)]
+struct RegisterRequest<'a> {
+    registration_credentials: &'a str,
+    version: &'a str,
+    capabilities: &'a [String],
+}
+
+#[derive(Serialize)]
+struct VerifyRequest<'a> {
+    registration_credentials: &'a str,
+}
+
+#[derive(Deserialize)]
+struct AccessResponse {
+    robot_id: Option<Uuid>,
+    access_token: Option<String>,
+    access_expires_at: Option<String>,
+}
+
+struct RobotAuthenticator {
+    base_url: Arc<String>,
+    registration_credentials: Arc<String>,
+    node_version: Arc<String>,
+    capabilities: Arc<Vec<String>>,
+    client: Client,
+    registered: AtomicBool,
+}
+
+impl RobotAuthenticator {
+    fn new(
+        base_url: Url,
+        registration_credentials: String,
+        node_version: String,
+        capabilities: Vec<String>,
+        request_timeout: Duration,
+    ) -> Result<Self> {
+        let registration_credentials = registration_credentials.trim().to_string();
+        if registration_credentials.is_empty() {
+            return Err(anyhow!("robot registration credentials must not be empty"));
+        }
+        let node_version = node_version.trim().to_string();
+        if node_version.is_empty() {
+            return Err(anyhow!("robot node version must not be empty"));
+        }
+
+        let client = Client::builder()
+            .use_rustls_tls()
+            .timeout(request_timeout)
+            .build()
+            .context("build DDS robot authentication client")?;
+
+        Ok(Self {
+            base_url: Arc::new(base_url.to_string()),
+            registration_credentials: Arc::new(registration_credentials),
+            node_version: Arc::new(node_version),
+            capabilities: Arc::new(capabilities),
+            client,
+            registered: AtomicBool::new(false),
+        })
+    }
+
+    async fn register(&self) -> std::result::Result<AccessBundle, SiweError> {
+        let endpoint = self.endpoint(REGISTER_PATH);
+        let response = self
+            .client
+            .post(endpoint)
+            .json(&RegisterRequest {
+                registration_credentials: self.registration_credentials.as_str(),
+                version: self.node_version.as_str(),
+                capabilities: self.capabilities.as_slice(),
+            })
+            .send()
+            .await?;
+        decode_access_response(response).await
+    }
+
+    async fn verify(&self) -> std::result::Result<AccessBundle, SiweError> {
+        let endpoint = self.endpoint(VERIFY_PATH);
+        let response = self
+            .client
+            .post(endpoint)
+            .json(&VerifyRequest {
+                registration_credentials: self.registration_credentials.as_str(),
+            })
+            .send()
+            .await?;
+        decode_access_response(response).await
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.base_url.trim_end_matches('/'), path)
+    }
+}
+
+#[async_trait]
+impl AccessAuthenticator for RobotAuthenticator {
+    async fn login(&self) -> std::result::Result<AccessBundle, SiweError> {
+        if self.registered.load(Ordering::Acquire) {
+            return self.verify().await;
+        }
+
+        let bundle = self.register().await?;
+        self.registered.store(true, Ordering::Release);
+        Ok(bundle)
+    }
+}
+
+async fn decode_access_response(
+    response: Response,
+) -> std::result::Result<AccessBundle, SiweError> {
+    if !response.status().is_success() {
+        return Err(SiweError::UpstreamStatus(response.status()));
+    }
+
+    let body: AccessResponse = response.json().await?;
+    if body.robot_id.filter(|id| !id.is_nil()).is_none() {
+        return Err(SiweError::MissingField("robot_id"));
+    }
+    let token = body
+        .access_token
+        .filter(|value| !value.is_empty())
+        .ok_or(SiweError::MissingField("access_token"))?;
+    let expires_at_raw = body
+        .access_expires_at
+        .ok_or(SiweError::MissingField("access_expires_at"))?;
+    let expires_at = DateTime::parse_from_rfc3339(&expires_at_raw)?.with_timezone(&Utc);
+
+    Ok(AccessBundle::new(token, expires_at))
+}
+
+/// Robot machine-authentication lifecycle for the compute-node engine.
+///
+/// A new instance always registers first. Once registration succeeds, all
+/// token refreshes use the verify endpoint and never fall back to SIWE.
+pub struct RobotMachineAuth {
+    authenticator: Arc<RobotAuthenticator>,
+    config: TokenManagerConfig,
+    manager: ManagerCell,
+}
+
+impl RobotMachineAuth {
+    pub fn from_config(cfg: &RobotNodeConfig, capabilities: Vec<String>) -> Result<Self> {
+        let token_config = TokenManagerConfig {
+            safety_ratio: cfg.token_safety_ratio as f64,
+            max_retries: cfg.token_reauth_max_retries,
+            jitter: Duration::from_millis(cfg.token_reauth_jitter_ms),
+        };
+
+        Self::new(
+            cfg.dds_base_url.clone(),
+            cfg.registration_credentials().to_string(),
+            cfg.node_version.clone(),
+            capabilities,
+            Duration::from_secs(cfg.request_timeout_secs.max(1)),
+            token_config,
+        )
+    }
+
+    pub fn new(
+        dds_base_url: Url,
+        registration_credentials: impl Into<String>,
+        node_version: impl Into<String>,
+        capabilities: Vec<String>,
+        request_timeout: Duration,
+        token_config: TokenManagerConfig,
+    ) -> Result<Self> {
+        let authenticator = Arc::new(RobotAuthenticator::new(
+            dds_base_url,
+            registration_credentials.into(),
+            node_version.into(),
+            capabilities,
+            request_timeout,
+        )?);
+        Ok(Self {
+            authenticator,
+            config: token_config,
+            manager: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub async fn start(&self) -> Result<RobotHandle> {
+        let mut guard = self.manager.lock().await;
+        if let Some(existing) = guard.as_ref() {
+            return Ok(RobotHandle {
+                manager: existing.clone(),
+            });
+        }
+
+        let manager = Arc::new(TokenManager::new(
+            Arc::clone(&self.authenticator),
+            Arc::new(SystemClock),
+            self.config.clone(),
+        ));
+
+        manager
+            .bearer()
+            .await
+            .map_err(|err| anyhow!("initial DDS robot authentication failed: {err}"))?;
+
+        // Track the authenticated manager before starting its owned task. If
+        // startup is cancelled at this boundary, `shutdown` can still stop it.
+        *guard = Some(manager.clone());
+        manager.start_bg().await;
+
+        Ok(RobotHandle { manager })
+    }
+
+    /// Stop and discard any token manager installed by [`Self::start`].
+    ///
+    /// Calling this after a cancelled startup is safe even when initial DDS
+    /// authentication never completed.
+    pub async fn shutdown(&self) {
+        let manager = self.manager.lock().await.take();
+        if let Some(manager) = manager {
+            manager.stop_bg().await;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RobotHandle {
+    manager: Arc<RobotTokenManager>,
+}
+
+impl RobotHandle {
+    pub async fn bearer(&self) -> Result<String, TokenProviderError> {
+        self.manager.bearer().await
+    }
+
+    pub async fn shutdown(&self) {
+        self.manager.stop_bg().await;
+    }
+}
+
+#[async_trait]
+impl TokenProvider for RobotHandle {
+    async fn bearer(&self) -> super::token_manager::TokenProviderResult<String> {
+        self.manager.bearer().await
+    }
+
+    async fn on_unauthorized(&self) {
+        self.manager.on_unauthorized_retry().await;
+    }
+}

--- a/core/compute-node/src/auth/token_manager.rs
+++ b/core/compute-node/src/auth/token_manager.rs
@@ -20,7 +20,7 @@ use super::siwe::{AccessBundle, SiweError};
 
 const DEFAULT_RATIO: f64 = 0.75;
 const MIN_DURATION: Duration = Duration::from_millis(1);
-const BACKGROUND_FAILURE_BACKOFF: Duration = Duration::from_secs(30);
+pub(crate) const AUTH_FAILURE_BACKOFF: Duration = Duration::from_secs(30);
 
 #[async_trait]
 pub trait AccessAuthenticator: Send + Sync {
@@ -80,6 +80,8 @@ pub enum TokenManagerError {
         #[source]
         last_error: SiweError,
     },
+    #[error("authentication retry is backing off")]
+    AuthenticationBackoff,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -147,6 +149,7 @@ where
 struct State {
     token: Option<TokenEntry>,
     inflight: Option<Arc<Notify>>,
+    retry_not_before: Option<Instant>,
 }
 
 #[derive(Clone)]
@@ -180,6 +183,7 @@ where
             state: Arc::new(Mutex::new(State {
                 token: None,
                 inflight: None,
+                retry_not_before: None,
             })),
             stopped: Arc::new(AtomicBool::new(false)),
             stop_notify: Arc::new(Notify::new()),
@@ -199,6 +203,12 @@ where
                     if entry.is_valid(now) {
                         return Ok(entry.value.clone());
                     }
+                }
+                if let Some(retry_not_before) = state.retry_not_before {
+                    if now < retry_not_before {
+                        return Err(TokenManagerError::AuthenticationBackoff);
+                    }
+                    state.retry_not_before = None;
                 }
                 match state.inflight.clone() {
                     Some(existing) => (existing, false),
@@ -220,10 +230,14 @@ where
                         Ok(entry) => {
                             let token = entry.value.clone();
                             state.token = Some(entry);
+                            state.retry_not_before = None;
                             refreshed = true;
                             Ok(token)
                         }
-                        Err(err) => Err(err),
+                        Err(err) => {
+                            state.retry_not_before = Some(now + AUTH_FAILURE_BACKOFF);
+                            Err(err)
+                        }
                     };
                     (notify_opt, outcome)
                 };
@@ -243,12 +257,14 @@ where
     pub async fn clear(&self) {
         let mut state = self.state.lock().await;
         state.token = None;
+        state.retry_not_before = None;
         drop(state);
         self.state_notify.notify_waiters();
     }
 
     pub async fn on_unauthorized_retry(&self) {
         let mut state = self.state.lock().await;
+        state.retry_not_before = None;
         if let Some(entry) = &mut state.token {
             let now = self.clock.now_instant();
             entry.refresh_at = now.checked_sub(MIN_DURATION).unwrap_or(now);
@@ -263,6 +279,7 @@ where
         let notify = {
             let mut state = self.state.lock().await;
             state.token = None;
+            state.retry_not_before = None;
             let inflight = state.inflight.take();
             drop(state);
             self.state_notify.notify_waiters();
@@ -443,7 +460,7 @@ where
                         if let Err(err) = self.get_access(now).await {
                             warn!(
                                 error = %err,
-                                retry_in_ms = BACKGROUND_FAILURE_BACKOFF.as_millis(),
+                                retry_in_ms = AUTH_FAILURE_BACKOFF.as_millis(),
                                 "Background DDS authentication attempt failed"
                             );
                             if !self.wait_after_background_failure().await {
@@ -469,7 +486,7 @@ where
                     if let Err(err) = self.get_access(now).await {
                         warn!(
                             error = %err,
-                            retry_in_ms = BACKGROUND_FAILURE_BACKOFF.as_millis(),
+                            retry_in_ms = AUTH_FAILURE_BACKOFF.as_millis(),
                             "Background DDS authentication attempt failed"
                         );
                         if !self.wait_after_background_failure().await {
@@ -495,7 +512,7 @@ where
         tokio::select! {
             _ = self.stop_notify.notified() => false,
             _ = self.state_notify.notified() => true,
-            _ = sleep(BACKGROUND_FAILURE_BACKOFF) => true,
+            _ = sleep(AUTH_FAILURE_BACKOFF) => true,
         }
     }
 
@@ -707,6 +724,48 @@ mod tests {
         let tokens: Vec<_> = futures::future::join_all(tasks).await;
         assert!(tokens.iter().all(|t| t == "token-1"));
         assert_eq!(auth.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_failed_access_shares_backoff_without_reauthenticating() {
+        let responses = VecDeque::from([
+            Err(SiweError::MissingField("access_token")),
+            Ok(access_bundle("recovered-token", 3600)),
+        ]);
+        let auth = Arc::new(QueueAuthenticator::new(responses));
+        let clock = Arc::new(TestClock::new());
+        let manager = TokenManager::with_rng(
+            auth.clone(),
+            clock.clone(),
+            TokenManagerConfig {
+                safety_ratio: 1.0,
+                max_retries: 0,
+                jitter: Duration::ZERO,
+            },
+            StdRng::seed_from_u64(43),
+        );
+
+        let now = clock.now_instant();
+        let tasks = (0..5).map(|_| {
+            let manager = manager.clone();
+            async move { manager.get_access(now).await }
+        });
+        let results: Vec<_> = futures::future::join_all(tasks).await;
+
+        assert!(results.iter().all(Result::is_err));
+        assert_eq!(auth.calls(), 1);
+        assert!(matches!(
+            manager.get_access(now).await,
+            Err(TokenManagerError::AuthenticationBackoff)
+        ));
+        assert_eq!(auth.calls(), 1);
+
+        *clock.instant_offset.lock().unwrap() += AUTH_FAILURE_BACKOFF;
+        assert_eq!(
+            manager.get_access(clock.now_instant()).await.unwrap(),
+            "recovered-token"
+        );
+        assert_eq!(auth.calls(), 2);
     }
 
     #[tokio::test]
@@ -933,7 +992,7 @@ mod tests {
         }
         assert_eq!(auth.calls(), 2);
 
-        advance(BACKGROUND_FAILURE_BACKOFF - Duration::from_millis(1)).await;
+        advance(AUTH_FAILURE_BACKOFF - Duration::from_millis(1)).await;
         yield_now().await;
         assert_eq!(auth.calls(), 2);
 

--- a/core/compute-node/src/auth/token_manager.rs
+++ b/core/compute-node/src/auth/token_manager.rs
@@ -20,6 +20,7 @@ use super::siwe::{AccessBundle, SiweError};
 
 const DEFAULT_RATIO: f64 = 0.75;
 const MIN_DURATION: Duration = Duration::from_millis(1);
+const BACKGROUND_FAILURE_BACKOFF: Duration = Duration::from_secs(30);
 
 #[async_trait]
 pub trait AccessAuthenticator: Send + Sync {
@@ -328,12 +329,12 @@ where
                         return Ok(entry);
                     }
                     Err(err) => {
-                        warn!(attempt, error = %err, "DDS SIWE response invalid");
+                        warn!(attempt, error = %err, "DDS authentication response invalid");
                         last_error = Some(err);
                     }
                 },
                 Err(err) => {
-                    warn!(attempt, error = %err, "DDS SIWE login failed");
+                    warn!(attempt, error = %err, "DDS authentication failed");
                     last_error = Some(err);
                 }
             }
@@ -440,7 +441,14 @@ where
                     let now = self.clock.now_instant();
                     if target <= now {
                         if let Err(err) = self.get_access(now).await {
-                            warn!(error = %err, "Background reauth attempt failed");
+                            warn!(
+                                error = %err,
+                                retry_in_ms = BACKGROUND_FAILURE_BACKOFF.as_millis(),
+                                "Background DDS authentication attempt failed"
+                            );
+                            if !self.wait_after_background_failure().await {
+                                break;
+                            }
                         }
                         continue;
                     }
@@ -459,7 +467,14 @@ where
 
                     let now = self.clock.now_instant();
                     if let Err(err) = self.get_access(now).await {
-                        warn!(error = %err, "Background reauth attempt failed");
+                        warn!(
+                            error = %err,
+                            retry_in_ms = BACKGROUND_FAILURE_BACKOFF.as_millis(),
+                            "Background DDS authentication attempt failed"
+                        );
+                        if !self.wait_after_background_failure().await {
+                            break;
+                        }
                     }
                 }
                 None => {
@@ -469,6 +484,18 @@ where
                     }
                 }
             }
+        }
+    }
+
+    async fn wait_after_background_failure(&self) -> bool {
+        if self.stopped.load(Ordering::SeqCst) {
+            return false;
+        }
+
+        tokio::select! {
+            _ = self.stop_notify.notified() => false,
+            _ = self.state_notify.notified() => true,
+            _ = sleep(BACKGROUND_FAILURE_BACKOFF) => true,
         }
     }
 
@@ -591,6 +618,39 @@ mod tests {
         ttl: chrono::Duration,
         calls: Mutex<Vec<tokio::time::Instant>>,
         counter: AtomicUsize,
+    }
+
+    struct SuccessThenFailAuthenticator {
+        clock: Arc<TokioTestClock>,
+        calls: AtomicUsize,
+    }
+
+    impl SuccessThenFailAuthenticator {
+        fn new(clock: Arc<TokioTestClock>) -> Self {
+            Self {
+                clock,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl AccessAuthenticator for SuccessThenFailAuthenticator {
+        async fn login(&self) -> Result<AccessBundle, SiweError> {
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            if call == 0 {
+                return Ok(AccessBundle::new(
+                    "initial-token",
+                    self.clock.now_utc() + chrono::Duration::seconds(10),
+                ));
+            }
+
+            Err(SiweError::MissingField("access_token"))
+        }
     }
 
     impl RecordingAuthenticator {
@@ -835,6 +895,58 @@ mod tests {
         let elapsed_std = Duration::from_secs_f64(elapsed.as_secs_f64());
         assert!(elapsed_std >= expected);
         assert!(elapsed_std <= expected + Duration::from_millis(10));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_refresh_failure_waits_before_retrying() {
+        let clock = Arc::new(TokioTestClock::new());
+        let auth = Arc::new(SuccessThenFailAuthenticator::new(clock.clone()));
+        let manager = TokenManager::with_rng(
+            auth.clone(),
+            clock.clone(),
+            TokenManagerConfig {
+                safety_ratio: 0.5,
+                max_retries: 0,
+                jitter: Duration::ZERO,
+            },
+            StdRng::seed_from_u64(456),
+        );
+
+        manager.start_bg().await;
+        for _ in 0..3 {
+            yield_now().await;
+        }
+        assert_eq!(
+            manager.get_access(clock.now_instant()).await.unwrap(),
+            "initial-token"
+        );
+        for _ in 0..3 {
+            yield_now().await;
+        }
+
+        manager.on_unauthorized_retry().await;
+        for _ in 0..5 {
+            yield_now().await;
+            if auth.calls() >= 2 {
+                break;
+            }
+        }
+        assert_eq!(auth.calls(), 2);
+
+        advance(BACKGROUND_FAILURE_BACKOFF - Duration::from_millis(1)).await;
+        yield_now().await;
+        assert_eq!(auth.calls(), 2);
+
+        advance(Duration::from_millis(1)).await;
+        for _ in 0..5 {
+            yield_now().await;
+            if auth.calls() >= 3 {
+                break;
+            }
+        }
+        assert_eq!(auth.calls(), 3);
+
+        manager.stop_bg().await;
     }
 
     #[tokio::test(start_paused = true)]

--- a/core/compute-node/src/config.rs
+++ b/core/compute-node/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
-use std::{env, fmt};
+use std::{env, fmt, fs};
 use url::Url;
 
 const DEFAULT_DMS_BASE_URL: &str = "https://dms.auki.network/v1";
@@ -224,18 +224,12 @@ impl RobotNodeConfig {
     /// Load the robot entrypoint configuration from environment variables.
     ///
     /// Unlike [`NodeConfig::from_env`], this requires only opaque robot
-    /// credentials. It never reads or falls back to the legacy SIWE secret or
-    /// secp256k1 private key.
+    /// credentials, supplied either inline or through a file. It never reads
+    /// or falls back to the legacy SIWE secret or secp256k1 private key.
     pub fn from_env() -> Result<Self> {
         let dms_base_url = parse_url_default("DMS_BASE_URL", DEFAULT_DMS_BASE_URL)?;
         let dds_base_url = parse_url_default("DDS_BASE_URL", DEFAULT_DDS_BASE_URL)?;
-        let registration_credentials =
-            env::var("ROBOT_REGISTRATION_CREDENTIALS").with_context(|| {
-                "ROBOT_REGISTRATION_CREDENTIALS required for robot machine authentication"
-            })?;
-        if registration_credentials.trim().is_empty() {
-            bail!("ROBOT_REGISTRATION_CREDENTIALS required for robot machine authentication");
-        }
+        let registration_credentials = robot_registration_credentials_from_env()?;
 
         let mut cfg = Self::new(dds_base_url, dms_base_url, registration_credentials)?;
         cfg.request_timeout_secs =
@@ -290,6 +284,41 @@ impl RobotNodeConfig {
             enable_noop: self.enable_noop,
             noop_sleep_secs: self.noop_sleep_secs,
         }
+    }
+}
+
+fn robot_registration_credentials_from_env() -> Result<String> {
+    let inline = env::var("ROBOT_REGISTRATION_CREDENTIALS").ok();
+    let file = env::var("ROBOT_REGISTRATION_CREDENTIALS_FILE").ok();
+
+    match (inline, file) {
+        (Some(_), Some(_)) => bail!(
+            "ROBOT_REGISTRATION_CREDENTIALS and ROBOT_REGISTRATION_CREDENTIALS_FILE are mutually exclusive"
+        ),
+        (Some(credentials), None) => {
+            let credentials = credentials.trim().to_string();
+            if credentials.is_empty() {
+                bail!("ROBOT_REGISTRATION_CREDENTIALS must not be empty");
+            }
+            Ok(credentials)
+        }
+        (None, Some(path)) => {
+            let path = path.trim();
+            if path.is_empty() {
+                bail!("ROBOT_REGISTRATION_CREDENTIALS_FILE must not be empty");
+            }
+            let credentials = fs::read_to_string(path).with_context(|| {
+                format!("read robot registration credentials file {path}")
+            })?;
+            let credentials = credentials.trim().to_string();
+            if credentials.is_empty() {
+                bail!("robot registration credentials file must not be empty");
+            }
+            Ok(credentials)
+        }
+        (None, None) => bail!(
+            "ROBOT_REGISTRATION_CREDENTIALS or ROBOT_REGISTRATION_CREDENTIALS_FILE required for robot machine authentication"
+        ),
     }
 }
 

--- a/core/compute-node/src/config.rs
+++ b/core/compute-node/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
-use std::env;
+use std::{env, fmt};
 use url::Url;
 
 const DEFAULT_DMS_BASE_URL: &str = "https://dms.auki.network/v1";
@@ -125,6 +125,171 @@ impl NodeConfig {
             enable_noop,
             noop_sleep_secs,
         })
+    }
+}
+
+/// Configuration for the opt-in robot machine-authentication entrypoint.
+///
+/// This is deliberately separate from [`NodeConfig`] so the existing SIWE
+/// configuration surface and public struct shape remain unchanged. Complete
+/// registration credentials are kept private and are always redacted from
+/// debug output.
+#[derive(Clone, PartialEq)]
+pub struct RobotNodeConfig {
+    // Core settings (defaults available).
+    pub dms_base_url: Url,
+    pub node_version: String,
+    pub request_timeout_secs: u64,
+
+    // Robot machine authentication.
+    pub dds_base_url: Url,
+    registration_credentials: String,
+
+    // Optional runtime tuning shared with the SIWE entrypoint.
+    pub heartbeat_jitter_ms: u64,
+    pub heartbeat_min_ratio: f64,
+    pub heartbeat_max_ratio: f64,
+    pub poll_backoff_ms_min: u64,
+    pub poll_backoff_ms_max: u64,
+    pub token_safety_ratio: f32,
+    pub token_reauth_max_retries: u32,
+    pub token_reauth_jitter_ms: u64,
+    pub max_concurrency: u32,
+    pub log_format: LogFormat,
+    pub enable_noop: bool,
+    pub noop_sleep_secs: u64,
+}
+
+impl fmt::Debug for RobotNodeConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RobotNodeConfig")
+            .field("dms_base_url", &self.dms_base_url)
+            .field("node_version", &self.node_version)
+            .field("request_timeout_secs", &self.request_timeout_secs)
+            .field("dds_base_url", &self.dds_base_url)
+            .field("registration_credentials", &"[REDACTED]")
+            .field("heartbeat_jitter_ms", &self.heartbeat_jitter_ms)
+            .field("heartbeat_min_ratio", &self.heartbeat_min_ratio)
+            .field("heartbeat_max_ratio", &self.heartbeat_max_ratio)
+            .field("poll_backoff_ms_min", &self.poll_backoff_ms_min)
+            .field("poll_backoff_ms_max", &self.poll_backoff_ms_max)
+            .field("token_safety_ratio", &self.token_safety_ratio)
+            .field("token_reauth_max_retries", &self.token_reauth_max_retries)
+            .field("token_reauth_jitter_ms", &self.token_reauth_jitter_ms)
+            .field("max_concurrency", &self.max_concurrency)
+            .field("log_format", &self.log_format)
+            .field("enable_noop", &self.enable_noop)
+            .field("noop_sleep_secs", &self.noop_sleep_secs)
+            .finish()
+    }
+}
+
+impl RobotNodeConfig {
+    /// Construct robot configuration without reading process-global state.
+    ///
+    /// Operational fields receive the same defaults as [`Self::from_env`] and
+    /// remain publicly overridable. The opaque credential stays private and is
+    /// redacted by this type's [`fmt::Debug`] implementation.
+    pub fn new(
+        dds_base_url: Url,
+        dms_base_url: Url,
+        registration_credentials: impl Into<String>,
+    ) -> Result<Self> {
+        let registration_credentials = registration_credentials.into().trim().to_string();
+        if registration_credentials.is_empty() {
+            bail!("robot registration credentials must not be empty");
+        }
+
+        Ok(Self {
+            dms_base_url,
+            node_version: env!("CARGO_PKG_VERSION").to_string(),
+            request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
+            dds_base_url,
+            registration_credentials,
+            heartbeat_jitter_ms: 250,
+            heartbeat_min_ratio: DEFAULT_HEARTBEAT_MIN_RATIO,
+            heartbeat_max_ratio: DEFAULT_HEARTBEAT_MAX_RATIO,
+            poll_backoff_ms_min: 1000,
+            poll_backoff_ms_max: 30000,
+            token_safety_ratio: 0.75,
+            token_reauth_max_retries: 3,
+            token_reauth_jitter_ms: 500,
+            max_concurrency: 1,
+            log_format: LogFormat::default(),
+            enable_noop: false,
+            noop_sleep_secs: 5,
+        })
+    }
+
+    /// Load the robot entrypoint configuration from environment variables.
+    ///
+    /// Unlike [`NodeConfig::from_env`], this requires only opaque robot
+    /// credentials. It never reads or falls back to the legacy SIWE secret or
+    /// secp256k1 private key.
+    pub fn from_env() -> Result<Self> {
+        let dms_base_url = parse_url_default("DMS_BASE_URL", DEFAULT_DMS_BASE_URL)?;
+        let dds_base_url = parse_url_default("DDS_BASE_URL", DEFAULT_DDS_BASE_URL)?;
+        let registration_credentials =
+            env::var("ROBOT_REGISTRATION_CREDENTIALS").with_context(|| {
+                "ROBOT_REGISTRATION_CREDENTIALS required for robot machine authentication"
+            })?;
+        if registration_credentials.trim().is_empty() {
+            bail!("ROBOT_REGISTRATION_CREDENTIALS required for robot machine authentication");
+        }
+
+        let mut cfg = Self::new(dds_base_url, dms_base_url, registration_credentials)?;
+        cfg.request_timeout_secs =
+            parse_u64_default("REQUEST_TIMEOUT_SECS", DEFAULT_REQUEST_TIMEOUT_SECS)?;
+        cfg.node_version = env_var_trimmed("NODE_VERSION")
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+        cfg.heartbeat_jitter_ms = parse_u64_opt("HEARTBEAT_JITTER_MS", 250)?;
+        cfg.heartbeat_min_ratio =
+            parse_f64_opt("HEARTBEAT_MIN_RATIO", DEFAULT_HEARTBEAT_MIN_RATIO)?;
+        cfg.heartbeat_max_ratio =
+            parse_f64_opt("HEARTBEAT_MAX_RATIO", DEFAULT_HEARTBEAT_MAX_RATIO)?;
+        cfg.poll_backoff_ms_min = parse_u64_opt("POLL_BACKOFF_MS_MIN", 1000)?;
+        cfg.poll_backoff_ms_max = parse_u64_opt("POLL_BACKOFF_MS_MAX", 30000)?;
+        cfg.token_safety_ratio = parse_f32_opt("TOKEN_SAFETY_RATIO", 0.75)?;
+        cfg.token_reauth_max_retries = parse_u32_opt("TOKEN_REAUTH_MAX_RETRIES", 3)?;
+        cfg.token_reauth_jitter_ms = parse_u64_opt("TOKEN_REAUTH_JITTER_MS", 500)?;
+        cfg.max_concurrency = parse_u32_opt("MAX_CONCURRENCY", 1)?;
+        cfg.log_format = parse_log_format("LOG_FORMAT").unwrap_or_default();
+        cfg.enable_noop = parse_bool_opt("ENABLE_NOOP", false)?;
+        cfg.noop_sleep_secs = parse_u64_opt("NOOP_SLEEP_SECS", 5)?;
+
+        Ok(cfg)
+    }
+
+    pub(crate) fn registration_credentials(&self) -> &str {
+        &self.registration_credentials
+    }
+
+    /// Produce the existing engine configuration used by the shared runner,
+    /// heartbeat, storage, and DMS loop. SIWE-only fields remain empty and are
+    /// never consulted by the robot entrypoint.
+    pub(crate) fn runtime_config(&self) -> NodeConfig {
+        NodeConfig {
+            dms_base_url: self.dms_base_url.clone(),
+            node_version: self.node_version.clone(),
+            request_timeout_secs: self.request_timeout_secs,
+            dds_base_url: Some(self.dds_base_url.clone()),
+            reg_secret: None,
+            secp256k1_privhex: None,
+            heartbeat_jitter_ms: self.heartbeat_jitter_ms,
+            heartbeat_min_ratio: self.heartbeat_min_ratio,
+            heartbeat_max_ratio: self.heartbeat_max_ratio,
+            poll_backoff_ms_min: self.poll_backoff_ms_min,
+            poll_backoff_ms_max: self.poll_backoff_ms_max,
+            token_safety_ratio: self.token_safety_ratio,
+            token_reauth_max_retries: self.token_reauth_max_retries,
+            token_reauth_jitter_ms: self.token_reauth_jitter_ms,
+            register_interval_secs: None,
+            register_max_retry: None,
+            max_concurrency: self.max_concurrency,
+            log_format: self.log_format,
+            enable_noop: self.enable_noop,
+            noop_sleep_secs: self.noop_sleep_secs,
+        }
     }
 }
 

--- a/core/compute-node/src/dms/client.rs
+++ b/core/compute-node/src/dms/client.rs
@@ -8,7 +8,6 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
     StatusCode,
 };
-use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::Level;
@@ -80,10 +79,8 @@ impl DmsClient {
         let mut bytes = res.bytes().await.context("read lease body")?;
         // Retry once on 401
         if status == StatusCode::UNAUTHORIZED {
-            let body_preview = String::from_utf8_lossy(&bytes);
             tracing::warn!(
                 status = %status,
-                body = %body_preview,
                 "DMS lease unauthorized; refreshing token and retrying"
             );
             self.auth.on_unauthorized().await;
@@ -102,11 +99,9 @@ impl DmsClient {
             tracing::debug!("DMS lease returned 204 (no work available)");
             return Ok(None);
         }
-        let body_preview = String::from_utf8_lossy(&bytes);
         if status == StatusCode::CONFLICT {
             tracing::debug!(
                 status = %status,
-                body = %body_preview,
                 "DMS lease returned conflict (busy); treating as no work"
             );
             return Ok(None);
@@ -114,7 +109,6 @@ impl DmsClient {
         if !status.is_success() {
             tracing::warn!(
                 status = %status,
-                body = %body_preview,
                 "DMS lease request returned non-success status"
             );
             return Err(anyhow!("/tasks status: {}", status));
@@ -122,8 +116,8 @@ impl DmsClient {
         let lease: LeaseResponse = serde_json::from_slice(&bytes)
             .map_err(|err| {
                 tracing::error!(
+                    status = %status,
                     error = %err,
-                    body = %body_preview,
                     "Failed to decode DMS lease response"
                 );
                 err
@@ -133,7 +127,9 @@ impl DmsClient {
         if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 status = %status,
-                body = %body_preview,
+                task_id = %lease.task.id,
+                capability = %lease.task.capability,
+                access_token_updated = lease.access_token.is_some(),
                 "Decoded DMS lease response"
             );
         }
@@ -148,11 +144,10 @@ impl DmsClient {
             .context("join /complete")?;
         let mut headers = self.auth_headers().await?;
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        if let Some(preview) = json_debug_preview(body) {
+        if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 endpoint = %url,
                 task_id = %task_id,
-                body = %preview,
                 "Sending DMS complete request"
             );
         }
@@ -166,15 +161,10 @@ impl DmsClient {
             .await
             .context("send POST /complete")?;
         let mut status = res.status();
-        let mut body_text = res
-            .text()
-            .await
-            .unwrap_or_else(|e| format!("<failed to read body: {e}>"));
+        let _ = res.bytes().await;
         if status == StatusCode::UNAUTHORIZED {
-            let preview = truncate_preview(&body_text);
             tracing::warn!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS complete unauthorized; refreshing token and retrying"
             );
@@ -189,16 +179,11 @@ impl DmsClient {
                 .await
                 .context("retry POST /complete")?;
             status = res.status();
-            body_text = res
-                .text()
-                .await
-                .unwrap_or_else(|e| format!("<failed to read body (retry): {e}>"));
+            let _ = res.bytes().await;
         }
-        let preview = truncate_preview(&body_text);
         if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS complete response"
             );
@@ -206,13 +191,10 @@ impl DmsClient {
         if !status.is_success() {
             tracing::error!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS complete endpoint returned non-success status"
             );
-            return Err(anyhow!(
-                "POST /tasks/{task_id}/complete status {status}; body: {preview}"
-            ));
+            return Err(anyhow!("POST /tasks/{task_id}/complete status {status}"));
         }
         Ok(())
     }
@@ -224,11 +206,10 @@ impl DmsClient {
             .context("join /fail")?;
         let mut headers = self.auth_headers().await?;
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        if let Some(preview) = json_debug_preview(body) {
+        if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 endpoint = %url,
                 task_id = %task_id,
-                body = %preview,
                 "Sending DMS fail request"
             );
         }
@@ -242,15 +223,10 @@ impl DmsClient {
             .await
             .context("send POST /fail")?;
         let mut status = res.status();
-        let mut body_text = res
-            .text()
-            .await
-            .unwrap_or_else(|e| format!("<failed to read body: {e}>"));
+        let _ = res.bytes().await;
         if status == StatusCode::UNAUTHORIZED {
-            let preview = truncate_preview(&body_text);
             tracing::warn!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS fail unauthorized; refreshing token and retrying"
             );
@@ -265,16 +241,11 @@ impl DmsClient {
                 .await
                 .context("retry POST /fail")?;
             status = res.status();
-            body_text = res
-                .text()
-                .await
-                .unwrap_or_else(|e| format!("<failed to read body (retry): {e}>"));
+            let _ = res.bytes().await;
         }
-        let preview = truncate_preview(&body_text);
         if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS fail response"
             );
@@ -282,13 +253,10 @@ impl DmsClient {
         if !status.is_success() {
             tracing::error!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS fail endpoint returned non-success status"
             );
-            return Err(anyhow!(
-                "POST /tasks/{task_id}/fail status {status}; body: {preview}"
-            ));
+            return Err(anyhow!("POST /tasks/{task_id}/fail status {status}"));
         }
         Ok(())
     }
@@ -305,11 +273,10 @@ impl DmsClient {
             .context("join /heartbeat")?;
         let mut headers = self.auth_headers().await?;
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        if let Some(preview) = json_debug_preview(body) {
+        if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 endpoint = %url,
                 task_id = %task_id,
-                body = %preview,
                 "Sending DMS heartbeat request"
             );
         }
@@ -325,10 +292,8 @@ impl DmsClient {
         let mut status = res.status();
         let mut bytes = res.bytes().await.context("read heartbeat response body")?;
         if status == StatusCode::UNAUTHORIZED {
-            let preview = truncate_preview(&String::from_utf8_lossy(&bytes));
             tracing::warn!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
                 "DMS heartbeat unauthorized; refreshing token and retrying"
             );
@@ -348,42 +313,34 @@ impl DmsClient {
                 .await
                 .context("read heartbeat response body (retry)")?;
         }
-        let preview = truncate_preview(&String::from_utf8_lossy(&bytes));
+        if !status.is_success() {
+            tracing::warn!(
+                status = %status,
+                task_id = %task_id,
+                "DMS heartbeat endpoint returned non-success status"
+            );
+            return Err(anyhow!("POST /tasks/{task_id}/heartbeat status {status}"));
+        }
+        let hb = serde_json::from_slice::<HeartbeatResponse>(&bytes)
+            .map_err(|err| {
+                tracing::error!(
+                    status = %status,
+                    task_id = %task_id,
+                    error = %err,
+                    "Failed to decode DMS heartbeat response"
+                );
+                err
+            })
+            .context("decode heartbeat response")?;
         if tracing::enabled!(Level::DEBUG) {
             tracing::debug!(
                 status = %status,
-                body = %preview,
                 task_id = %task_id,
-                "DMS heartbeat response"
+                access_token_updated = hb.access_token.is_some(),
+                cancel = ?hb.cancel,
+                "Decoded DMS heartbeat response"
             );
         }
-        if !status.is_success() {
-            return Err(anyhow!(
-                "POST /tasks/{task_id}/heartbeat status {status}; body: {preview}"
-            ));
-        }
-        let hb = serde_json::from_slice::<HeartbeatResponse>(&bytes)
-            .context("decode heartbeat response")?;
         Ok(hb)
     }
-}
-
-fn truncate_preview(body: &str) -> String {
-    const MAX: usize = 512;
-    if body.len() <= MAX {
-        body.to_string()
-    } else {
-        let mut preview: String = body.chars().take(MAX).collect();
-        preview.push_str("… (truncated)");
-        preview
-    }
-}
-
-fn json_debug_preview<T: Serialize>(value: &T) -> Option<String> {
-    if !tracing::enabled!(Level::DEBUG) {
-        return None;
-    }
-    serde_json::to_string(value)
-        .map(|s| truncate_preview(&s))
-        .ok()
 }

--- a/core/compute-node/src/engine.rs
+++ b/core/compute-node/src/engine.rs
@@ -14,6 +14,8 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::{
+    auth::token_manager::TokenProvider,
+    config::{NodeConfig, RobotNodeConfig},
     dms::client::DmsClient,
     heartbeat::{progress_channel, ProgressReceiver, ProgressSender},
     poller::{jittered_delay_ms, PollerConfig},
@@ -108,6 +110,71 @@ pub async fn run_node_with_shutdown(
     let siwe_handle = siwe.start().await?;
     info!("DDS SIWE token manager started");
 
+    let auth: Arc<dyn TokenProvider> = Arc::new(siwe_handle.clone());
+    let result = run_authenticated_node_loop(&cfg, &runners, auth, shutdown, "SIWE", false).await;
+
+    siwe_handle.shutdown().await;
+    info!("Shutdown signal received; exiting run_node loop");
+
+    result
+}
+
+/// Run a robot-authenticated node until interrupted.
+pub async fn run_robot_node(cfg: RobotNodeConfig, runners: RunnerRegistry) -> Result<()> {
+    let shutdown = CancellationToken::new();
+    let signal_token = shutdown.clone();
+    let signal_task = tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            signal_token.cancel();
+        }
+    });
+
+    let result = run_robot_node_with_shutdown(cfg, runners, shutdown.clone()).await;
+
+    shutdown.cancel();
+    signal_task.abort();
+    let _ = signal_task.await;
+
+    result
+}
+
+/// Run a robot-authenticated node until the supplied cancellation token fires.
+pub async fn run_robot_node_with_shutdown(
+    cfg: RobotNodeConfig,
+    runners: RunnerRegistry,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let runtime_cfg = cfg.runtime_config();
+    let robot = crate::auth::RobotMachineAuth::from_config(&cfg, runners.capabilities())?;
+    info!("DDS robot authentication configured");
+    let robot_handle = tokio::select! {
+        result = robot.start() => result?,
+        _ = shutdown.cancelled() => {
+            robot.shutdown().await;
+            info!("Shutdown signal received before robot authentication completed");
+            return Ok(());
+        }
+    };
+    info!("DDS robot token manager started");
+
+    let auth: Arc<dyn TokenProvider> = Arc::new(robot_handle.clone());
+    let result =
+        run_authenticated_node_loop(&runtime_cfg, &runners, auth, shutdown, "robot", true).await;
+
+    robot_handle.shutdown().await;
+    info!("Shutdown signal received; exiting robot node loop");
+
+    result
+}
+
+async fn run_authenticated_node_loop(
+    cfg: &NodeConfig,
+    runners: &RunnerRegistry,
+    auth: Arc<dyn TokenProvider>,
+    shutdown: CancellationToken,
+    auth_kind: &'static str,
+    interrupt_on_shutdown: bool,
+) -> Result<()> {
     let poll_cfg = PollerConfig {
         backoff_ms_min: cfg.poll_backoff_ms_min,
         backoff_ms_max: cfg.poll_backoff_ms_max,
@@ -118,9 +185,17 @@ pub async fn run_node_with_shutdown(
             break;
         }
 
-        // Ensure SIWE token is available before attempting DMS operations
-        if let Err(err) = siwe_handle.bearer().await {
-            warn!(error = %err, "Failed to obtain SIWE bearer token; backing off");
+        // Ensure a token is available before attempting DMS operations.
+        let bearer = if interrupt_on_shutdown {
+            tokio::select! {
+                result = auth.bearer() => result,
+                _ = shutdown.cancelled() => break,
+            }
+        } else {
+            auth.bearer().await
+        };
+        if let Err(err) = bearer {
+            warn!(auth_kind, error = %err, "Failed to obtain bearer token; backing off");
             let delay_ms = jittered_delay_ms(poll_cfg);
             tokio::select! {
                 _ = shutdown.cancelled() => break,
@@ -132,7 +207,7 @@ pub async fn run_node_with_shutdown(
         let dms_client = match crate::dms::client::DmsClient::new(
             cfg.dms_base_url.clone(),
             timeout,
-            std::sync::Arc::new(siwe_handle.clone()),
+            auth.clone(),
         ) {
             Ok(client) => client,
             Err(err) => {
@@ -145,7 +220,24 @@ pub async fn run_node_with_shutdown(
             }
         };
 
-        match run_cycle_with_dms(&cfg, &dms_client, &runners).await {
+        let cycle = if interrupt_on_shutdown {
+            let acquired = tokio::select! {
+                biased;
+                result = acquire_lease_with_dms(&dms_client, runners) => result,
+                _ = shutdown.cancelled() => break,
+            };
+            match acquired {
+                Ok(Some(acquired)) => {
+                    run_leased_cycle_with_dms(cfg, &dms_client, runners, acquired).await
+                }
+                Ok(None) => Ok(false),
+                Err(err) => Err(err),
+            }
+        } else {
+            run_cycle_with_dms(cfg, &dms_client, runners).await
+        };
+
+        match cycle {
             Ok(true) => {
                 // Successful task execution; immediately attempt next poll.
                 continue;
@@ -168,9 +260,6 @@ pub async fn run_node_with_shutdown(
             }
         }
     }
-
-    siwe_handle.shutdown().await;
-    info!("Shutdown signal received; exiting run_node loop");
 
     Ok(())
 }
@@ -247,22 +336,50 @@ pub async fn run_cycle_with_dms(
     dms: &DmsClient,
     reg: &RunnerRegistry,
 ) -> Result<bool> {
-    use crate::dms::types::{CompleteTaskRequest, FailTaskRequest, HeartbeatRequest};
-    use serde_json::json;
+    let Some(acquired) = acquire_lease_with_dms(dms, reg).await? else {
+        return Ok(false);
+    };
+    run_leased_cycle_with_dms(cfg, dms, reg, acquired).await
+}
 
+struct AcquiredLease {
+    capabilities: Vec<String>,
+    lease: LeaseEnvelope,
+}
+
+async fn acquire_lease_with_dms(
+    dms: &DmsClient,
+    reg: &RunnerRegistry,
+) -> Result<Option<AcquiredLease>> {
     let capabilities = reg.capabilities();
     let capability = capabilities
         .first()
         .cloned()
         .ok_or_else(|| anyhow!("no runners registered"))?;
 
-    // Lease a task from DMS
-    let mut lease = match dms.lease_by_capability(&capability).await? {
-        Some(lease) => lease,
-        None => {
-            return Ok(false);
-        }
+    let Some(lease) = dms.lease_by_capability(&capability).await? else {
+        return Ok(None);
     };
+
+    Ok(Some(AcquiredLease {
+        capabilities,
+        lease,
+    }))
+}
+
+async fn run_leased_cycle_with_dms(
+    cfg: &crate::config::NodeConfig,
+    dms: &DmsClient,
+    reg: &RunnerRegistry,
+    acquired: AcquiredLease,
+) -> Result<bool> {
+    use crate::dms::types::{CompleteTaskRequest, FailTaskRequest, HeartbeatRequest};
+    use serde_json::json;
+
+    let AcquiredLease {
+        capabilities,
+        mut lease,
+    } = acquired;
     if lease.access_token.is_none() {
         tracing::warn!(
             "Lease missing access token; storage client will fall back to legacy token flow"

--- a/core/compute-node/src/engine.rs
+++ b/core/compute-node/src/engine.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::{
-    auth::token_manager::TokenProvider,
+    auth::token_manager::{TokenProvider, AUTH_FAILURE_BACKOFF},
     config::{NodeConfig, RobotNodeConfig},
     dms::client::DmsClient,
     heartbeat::{progress_channel, ProgressReceiver, ProgressSender},
@@ -197,9 +197,15 @@ async fn run_authenticated_node_loop(
         if let Err(err) = bearer {
             warn!(auth_kind, error = %err, "Failed to obtain bearer token; backing off");
             let delay_ms = jittered_delay_ms(poll_cfg);
+            let delay = StdDuration::from_millis(delay_ms);
+            let delay = if interrupt_on_shutdown {
+                delay.max(AUTH_FAILURE_BACKOFF)
+            } else {
+                delay
+            };
             tokio::select! {
                 _ = shutdown.cancelled() => break,
-                _ = sleep(StdDuration::from_millis(delay_ms)) => continue,
+                _ = sleep(delay) => continue,
             }
         }
 

--- a/core/compute-node/src/storage/client.rs
+++ b/core/compute-node/src/storage/client.rs
@@ -956,14 +956,10 @@ fn parse_download_target(
                     .map(|s| s.to_string()),
             ),
             "name" => {
-                if name.is_none() {
-                    name = Some(value.to_string());
-                }
+                name.get_or_insert_with(|| value.to_string());
             }
             "data_type" => {
-                if data_type.is_none() {
-                    data_type = Some(value.to_string());
-                }
+                data_type.get_or_insert_with(|| value.to_string());
             }
             _ => {}
         }

--- a/core/compute-node/tests/config_tests.rs
+++ b/core/compute-node/tests/config_tests.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use posemesh_compute_node::config::{LogFormat, NodeConfig};
+use posemesh_compute_node::config::{LogFormat, NodeConfig, RobotNodeConfig};
 use std::sync::Mutex;
 
 static ENV_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
@@ -108,4 +108,113 @@ fn log_format_text_is_parsed() {
 
     let cfg = NodeConfig::from_env().expect("config");
     assert_eq!(cfg.log_format, LogFormat::Text);
+}
+
+#[test]
+fn loads_robot_defaults_without_siwe_fields_and_redacts_credentials() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "NODE_VERSION",
+        "HEARTBEAT_JITTER_MS",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+        "POLL_BACKOFF_MS_MIN",
+        "POLL_BACKOFF_MS_MAX",
+        "TOKEN_SAFETY_RATIO",
+        "TOKEN_REAUTH_MAX_RETRIES",
+        "TOKEN_REAUTH_JITTER_MS",
+        "MAX_CONCURRENCY",
+        "LOG_FORMAT",
+        "ENABLE_NOOP",
+        "NOOP_SLEEP_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "REG_SECRET",
+        "SECP256K1_PRIVHEX",
+    ]);
+
+    let credentials = "opaque-robot-id-and-secret";
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS", credentials);
+
+    let cfg = RobotNodeConfig::from_env().expect("robot config");
+    assert_eq!(cfg.dms_base_url.as_str(), "https://dms.auki.network/v1");
+    assert_eq!(cfg.dds_base_url.as_str(), "https://dds.auki.network/");
+    assert_eq!(cfg.node_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(cfg.request_timeout_secs, 60);
+    assert_eq!(cfg.heartbeat_jitter_ms, 250);
+    assert!((cfg.heartbeat_min_ratio - 0.25).abs() < f64::EPSILON);
+    assert!((cfg.heartbeat_max_ratio - 0.35).abs() < f64::EPSILON);
+    assert_eq!(cfg.poll_backoff_ms_min, 1000);
+    assert_eq!(cfg.poll_backoff_ms_max, 30000);
+    assert!((cfg.token_safety_ratio - 0.75).abs() < f32::EPSILON);
+    assert_eq!(cfg.token_reauth_max_retries, 3);
+    assert_eq!(cfg.token_reauth_jitter_ms, 500);
+    assert_eq!(cfg.max_concurrency, 1);
+    assert_eq!(cfg.log_format, LogFormat::Json);
+    assert!(!cfg.enable_noop);
+    assert_eq!(cfg.noop_sleep_secs, 5);
+
+    let debug = format!("{cfg:?}");
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains(credentials));
+}
+
+#[test]
+fn constructs_robot_config_without_process_environment() {
+    let credentials = "programmatic-opaque-credentials";
+    let cfg = RobotNodeConfig::new(
+        "https://dds.example/".parse().unwrap(),
+        "https://dms.example/v1".parse().unwrap(),
+        credentials,
+    )
+    .expect("programmatic robot config");
+
+    assert_eq!(cfg.dds_base_url.as_str(), "https://dds.example/");
+    assert_eq!(cfg.dms_base_url.as_str(), "https://dms.example/v1");
+    assert_eq!(cfg.node_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(cfg.request_timeout_secs, 60);
+    assert!(!format!("{cfg:?}").contains(credentials));
+}
+
+#[test]
+fn robot_credentials_are_required_and_must_not_be_blank() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+    ]);
+
+    let err = RobotNodeConfig::from_env().expect_err("missing credentials must fail");
+    assert!(err.to_string().contains("ROBOT_REGISTRATION_CREDENTIALS"));
+
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS", "   ");
+    let err = RobotNodeConfig::from_env().expect_err("blank credentials must fail");
+    assert!(err.to_string().contains("ROBOT_REGISTRATION_CREDENTIALS"));
+}
+
+#[test]
+fn robot_credentials_do_not_switch_the_existing_siwe_loader() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "REG_SECRET",
+        "SECP256K1_PRIVHEX",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+    ]);
+
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS", "opaque-robot-credentials");
+    std::env::set_var("SECP256K1_PRIVHEX", "abcdef");
+
+    let err = NodeConfig::from_env().expect_err("SIWE must remain the default loader");
+    assert!(err.to_string().contains("REG_SECRET required"));
 }

--- a/core/compute-node/tests/config_tests.rs
+++ b/core/compute-node/tests/config_tests.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use posemesh_compute_node::config::{LogFormat, NodeConfig, RobotNodeConfig};
 use std::sync::Mutex;
+use tempfile::NamedTempFile;
 
 static ENV_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
@@ -131,6 +132,7 @@ fn loads_robot_defaults_without_siwe_fields_and_redacts_credentials() {
         "NOOP_SLEEP_SECS",
         "DDS_BASE_URL",
         "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
         "REG_SECRET",
         "SECP256K1_PRIVHEX",
     ]);
@@ -186,6 +188,7 @@ fn robot_credentials_are_required_and_must_not_be_blank() {
         "REQUEST_TIMEOUT_SECS",
         "DDS_BASE_URL",
         "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
         "HEARTBEAT_MIN_RATIO",
         "HEARTBEAT_MAX_RATIO",
     ]);
@@ -199,6 +202,85 @@ fn robot_credentials_are_required_and_must_not_be_blank() {
 }
 
 #[test]
+fn loads_robot_credentials_from_file_and_trims_newline() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+    ]);
+
+    let credentials = "opaque-file-robot-credentials";
+    let file = NamedTempFile::new().expect("credential file");
+    std::fs::write(file.path(), format!("{credentials}\n")).expect("write credential file");
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS_FILE", file.path());
+
+    let cfg = RobotNodeConfig::from_env().expect("robot file config");
+    let expected = RobotNodeConfig::new(
+        "https://dds.auki.network".parse().unwrap(),
+        "https://dms.auki.network/v1".parse().unwrap(),
+        credentials,
+    )
+    .expect("expected robot config");
+    assert_eq!(cfg, expected);
+    let debug = format!("{cfg:?}");
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains(credentials));
+}
+
+#[test]
+fn robot_credential_sources_are_mutually_exclusive() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+    ]);
+
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS", "inline-credentials");
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS_FILE", "/not/read");
+
+    let err = RobotNodeConfig::from_env().expect_err("ambiguous credentials must fail");
+    assert!(err.to_string().contains("mutually exclusive"));
+}
+
+#[test]
+fn robot_credential_file_must_be_readable_and_nonempty() {
+    let _g = ENV_GUARD.lock().unwrap();
+    clear(&[
+        "DMS_BASE_URL",
+        "REQUEST_TIMEOUT_SECS",
+        "DDS_BASE_URL",
+        "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
+        "HEARTBEAT_MIN_RATIO",
+        "HEARTBEAT_MAX_RATIO",
+    ]);
+
+    std::env::set_var(
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
+        "/definitely/missing/robot-credentials",
+    );
+    let err = RobotNodeConfig::from_env().expect_err("missing file must fail");
+    assert!(err
+        .to_string()
+        .contains("read robot registration credentials file"));
+
+    let file = NamedTempFile::new().expect("empty credential file");
+    std::env::set_var("ROBOT_REGISTRATION_CREDENTIALS_FILE", file.path());
+    let err = RobotNodeConfig::from_env().expect_err("empty file must fail");
+    assert!(err.to_string().contains("file must not be empty"));
+}
+
+#[test]
 fn robot_credentials_do_not_switch_the_existing_siwe_loader() {
     let _g = ENV_GUARD.lock().unwrap();
     clear(&[
@@ -206,6 +288,7 @@ fn robot_credentials_do_not_switch_the_existing_siwe_loader() {
         "REQUEST_TIMEOUT_SECS",
         "DDS_BASE_URL",
         "ROBOT_REGISTRATION_CREDENTIALS",
+        "ROBOT_REGISTRATION_CREDENTIALS_FILE",
         "REG_SECRET",
         "SECP256K1_PRIVHEX",
         "HEARTBEAT_MIN_RATIO",

--- a/core/compute-node/tests/dms_log_redaction.rs
+++ b/core/compute-node/tests/dms_log_redaction.rs
@@ -1,0 +1,213 @@
+use async_trait::async_trait;
+use httpmock::prelude::*;
+use posemesh_compute_node::auth::token_manager::{TokenProvider, TokenProviderResult};
+use posemesh_compute_node::dms::{client::DmsClient, types::HeartbeatRequest};
+use serde_json::json;
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::subscriber;
+use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, registry};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct RotatingProvider {
+    tokens: Arc<Vec<String>>,
+    current: Arc<AtomicUsize>,
+}
+
+impl RotatingProvider {
+    fn new(tokens: &[&str]) -> Self {
+        Self {
+            tokens: Arc::new(tokens.iter().map(|token| (*token).to_string()).collect()),
+            current: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenProvider for RotatingProvider {
+    async fn bearer(&self) -> TokenProviderResult<String> {
+        let index = self
+            .current
+            .load(Ordering::SeqCst)
+            .min(self.tokens.len() - 1);
+        Ok(self.tokens[index].clone())
+    }
+
+    async fn on_unauthorized(&self) {
+        self.current.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn dms_response_tokens_and_bodies_are_absent_from_logs_and_errors() {
+    const LEASE_TOKEN: &str = "secret-lease-task-access-token";
+    const HEARTBEAT_TOKEN: &str = "secret-heartbeat-task-access-token";
+    const LEASE_UNAUTHORIZED_BODY: &str = "secret-lease-unauthorized-body";
+    const HEARTBEAT_UNAUTHORIZED_BODY: &str = "secret-heartbeat-unauthorized-body";
+    const LEASE_ERROR_BODY: &str = "secret-lease-final-error-body";
+    const HEARTBEAT_ERROR_BODY: &str = "secret-heartbeat-final-error-body";
+
+    let server = MockServer::start();
+    let task_id = Uuid::new_v4();
+    let error_task_id = Uuid::new_v4();
+
+    let lease_unauthorized = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer node-token-a");
+        then.status(401).body(LEASE_UNAUTHORIZED_BODY);
+    });
+    let lease_success = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer node-token-b");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "access_token": LEASE_TOKEN,
+                "task": {
+                    "id": task_id,
+                    "capability": "/posemesh/redaction-test/v1"
+                }
+            }));
+    });
+    let heartbeat_unauthorized = server.mock(|when, then| {
+        when.method(POST)
+            .path(format!("/tasks/{task_id}/heartbeat"))
+            .header("authorization", "Bearer node-token-b");
+        then.status(401).body(HEARTBEAT_UNAUTHORIZED_BODY);
+    });
+    let heartbeat_success = server.mock(|when, then| {
+        when.method(POST)
+            .path(format!("/tasks/{task_id}/heartbeat"))
+            .header("authorization", "Bearer node-token-c");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "access_token": HEARTBEAT_TOKEN,
+                "task_id": task_id,
+                "cancel": false
+            }));
+    });
+    let lease_error = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer node-token-c");
+        then.status(502).body(LEASE_ERROR_BODY);
+    });
+    let heartbeat_error = server.mock(|when, then| {
+        when.method(POST)
+            .path(format!("/tasks/{error_task_id}/heartbeat"))
+            .header("authorization", "Bearer node-token-c");
+        then.status(503).body(HEARTBEAT_ERROR_BODY);
+    });
+
+    let (guard, logs) = capture_logs();
+    let provider = Arc::new(RotatingProvider::new(&[
+        "node-token-a",
+        "node-token-b",
+        "node-token-c",
+    ]));
+    let client = DmsClient::new(
+        server.base_url().parse().unwrap(),
+        Duration::from_secs(2),
+        provider,
+    )
+    .unwrap();
+
+    let lease = client
+        .lease_by_capability("/posemesh/redaction-test/v1")
+        .await
+        .unwrap()
+        .expect("lease after one 401 retry");
+    assert_eq!(lease.access_token.as_deref(), Some(LEASE_TOKEN));
+
+    let heartbeat = client
+        .heartbeat(task_id, &HeartbeatRequest::default())
+        .await
+        .expect("heartbeat after one 401 retry");
+    assert_eq!(heartbeat.access_token.as_deref(), Some(HEARTBEAT_TOKEN));
+
+    let lease_err = client
+        .lease_by_capability("/posemesh/redaction-test/v1")
+        .await
+        .expect_err("final lease error should be returned");
+    let heartbeat_err = client
+        .heartbeat(error_task_id, &HeartbeatRequest::default())
+        .await
+        .expect_err("final heartbeat error should be returned");
+    drop(guard);
+
+    lease_unauthorized.assert_hits(1);
+    lease_success.assert_hits(1);
+    heartbeat_unauthorized.assert_hits(1);
+    heartbeat_success.assert_hits(1);
+    lease_error.assert_hits(1);
+    heartbeat_error.assert_hits(1);
+
+    let lease_error_text = lease_err.to_string();
+    let heartbeat_error_text = heartbeat_err.to_string();
+    let captured = String::from_utf8(logs.lock().clone()).unwrap_or_default();
+    assert!(captured.contains("DMS lease unauthorized"));
+    assert!(captured.contains("Decoded DMS lease response"));
+    assert!(captured.contains("Decoded DMS heartbeat response"));
+    assert!(captured.contains(&task_id.to_string()));
+
+    for sensitive in [
+        "node-token-a",
+        "node-token-b",
+        "node-token-c",
+        LEASE_TOKEN,
+        HEARTBEAT_TOKEN,
+        LEASE_UNAUTHORIZED_BODY,
+        HEARTBEAT_UNAUTHORIZED_BODY,
+        LEASE_ERROR_BODY,
+        HEARTBEAT_ERROR_BODY,
+    ] {
+        assert!(
+            !captured.contains(sensitive),
+            "DMS logs exposed sensitive response data: {captured}"
+        );
+        assert!(!lease_error_text.contains(sensitive));
+        assert!(!heartbeat_error_text.contains(sensitive));
+    }
+}
+
+fn capture_logs() -> (
+    tracing::subscriber::DefaultGuard,
+    Arc<parking_lot::Mutex<Vec<u8>>>,
+) {
+    struct BufferWriter(Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl io::Write for BufferWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0.lock().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct MakeBufferWriter(Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeBufferWriter {
+        type Writer = BufferWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            BufferWriter(self.0.clone())
+        }
+    }
+
+    let buffer = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(MakeBufferWriter(buffer.clone()))
+        .with_ansi(false)
+        .without_time();
+    let guard = subscriber::set_default(registry().with(LevelFilter::DEBUG).with(layer));
+    (guard, buffer)
+}

--- a/core/compute-node/tests/engine_dms_flow.rs
+++ b/core/compute-node/tests/engine_dms_flow.rs
@@ -3,12 +3,16 @@ mod support;
 use async_trait::async_trait;
 use httpmock::prelude::*;
 use posemesh_compute_node::auth::token_manager::{TokenProvider, TokenProviderResult};
-use posemesh_compute_node::config::{LogFormat, NodeConfig};
+use posemesh_compute_node::config::{LogFormat, NodeConfig, RobotNodeConfig};
 use posemesh_compute_node::dms::client::DmsClient;
-use posemesh_compute_node::engine::{run_cycle_with_dms, run_node_with_shutdown, RunnerRegistry};
+use posemesh_compute_node::engine::{
+    run_cycle_with_dms, run_node_with_shutdown, run_robot_node_with_shutdown, RunnerRegistry,
+};
 use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -35,6 +39,21 @@ fn base_cfg() -> NodeConfig {
         enable_noop: true,
         noop_sleep_secs: 1,
     }
+}
+
+fn robot_cfg(server: &MockServer) -> RobotNodeConfig {
+    let base_url: url::Url = server.base_url().parse().unwrap();
+    let mut cfg = RobotNodeConfig::new(base_url.clone(), base_url, "robot-test-credentials")
+        .expect("robot test configuration");
+    cfg.node_version = "robot-test-version".to_string();
+    cfg.request_timeout_secs = 2;
+    cfg.heartbeat_jitter_ms = 0;
+    cfg.poll_backoff_ms_min = 1000;
+    cfg.poll_backoff_ms_max = 1000;
+    cfg.token_reauth_max_retries = 0;
+    cfg.token_reauth_jitter_ms = 0;
+    cfg.noop_sleep_secs = 0;
+    cfg
 }
 
 #[derive(Clone)]
@@ -490,9 +509,13 @@ async fn run_node_uses_siwe_token_and_completes_task() {
         shutdown.clone(),
     ));
 
-    // Allow the node to process at least one lease.
+    // Allow the node to acquire the lease and enter the heartbeat-backed
+    // execution path. A lease hit alone does not mean the async heartbeat
+    // request has reached the mock server yet.
     let start = Instant::now();
-    while lease_mock.hits() == 0 && start.elapsed() < Duration::from_millis(500) {
+    while (lease_mock.hits() == 0 || heartbeat_mock.hits() == 0)
+        && start.elapsed() < Duration::from_secs(2)
+    {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
@@ -535,4 +558,361 @@ async fn run_node_uses_siwe_token_and_completes_task() {
         .expect("run_node_with_shutdown should exit cleanly after cancellation");
 
     posemesh_compute_node::dds::persist::clear_node_secret().unwrap();
+}
+
+#[tokio::test]
+async fn run_robot_node_refreshes_after_dms_401_and_retries_with_machine_token() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+
+    let register_mock = server.mock({
+        let expires_at = expires_at.clone();
+        move |when, then| {
+            when.method(POST)
+                .path("/internal/v1/robots/register")
+                .body_contains("\"registration_credentials\":\"robot-test-credentials\"")
+                .body_contains("\"version\":\"robot-test-version\"")
+                .body_contains(support::mock_runner::MOCK_CAPABILITY);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "robot_id": robot_id,
+                    "access_token": "robot-token-a",
+                    "access_expires_at": expires_at,
+                }));
+        }
+    });
+    let verify_mock = server.mock({
+        let expires_at = expires_at.clone();
+        move |when, then| {
+            when.method(POST)
+                .path("/internal/v1/auth/robot/verify")
+                .body_contains("\"registration_credentials\":\"robot-test-credentials\"");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "robot_id": robot_id,
+                    "access_token": "robot-token-b",
+                    "access_expires_at": expires_at,
+                }));
+        }
+    });
+    let stale_lease_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer robot-token-a");
+        then.status(401);
+    });
+    let refreshed_lease_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer robot-token-b");
+        then.status(204);
+    });
+    let siwe_request_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/siwe/request");
+        then.status(500);
+    });
+    let siwe_verify_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/siwe/verify");
+        then.status(500);
+    });
+
+    let cfg = robot_cfg(&server);
+    let shutdown = CancellationToken::new();
+    let run_task = tokio::spawn(run_robot_node_with_shutdown(
+        cfg,
+        support::mock_runner::registry_with_mock(),
+        shutdown.clone(),
+    ));
+
+    let started = Instant::now();
+    while refreshed_lease_mock.hits() == 0 && started.elapsed() < Duration::from_secs(3) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(2), run_task)
+        .await
+        .expect("robot engine should stop promptly")
+        .expect("robot engine task join")
+        .expect("robot engine should shut down cleanly");
+
+    register_mock.assert_hits(1);
+    stale_lease_mock.assert_hits(1);
+    verify_mock.assert_hits(1);
+    refreshed_lease_mock.assert_hits(1);
+    siwe_request_mock.assert_hits(0);
+    siwe_verify_mock.assert_hits(0);
+}
+
+#[tokio::test]
+async fn run_robot_node_does_not_fall_back_to_siwe_when_verify_fails() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+
+    let register_mock = server.mock(move |when, then| {
+        when.method(POST).path("/internal/v1/robots/register");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "robot_id": robot_id,
+                "access_token": "robot-token-a",
+                "access_expires_at": expires_at,
+            }));
+    });
+    let verify_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/robot/verify");
+        then.status(403);
+    });
+    let stale_lease_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer robot-token-a");
+        then.status(401);
+    });
+    let siwe_request_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/siwe/request");
+        then.status(200);
+    });
+    let siwe_verify_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/siwe/verify");
+        then.status(200);
+    });
+
+    let cfg = robot_cfg(&server);
+    let shutdown = CancellationToken::new();
+    let run_task = tokio::spawn(run_robot_node_with_shutdown(
+        cfg,
+        support::mock_runner::registry_with_mock(),
+        shutdown.clone(),
+    ));
+
+    let started = Instant::now();
+    while verify_mock.hits() == 0 && started.elapsed() < Duration::from_secs(3) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_secs(2), run_task)
+        .await
+        .expect("robot engine should stop promptly after failed verification")
+        .expect("robot engine task join")
+        .expect("robot engine should shut down cleanly");
+
+    register_mock.assert_hits(1);
+    stale_lease_mock.assert_hits(1);
+    assert!(verify_mock.hits() >= 1, "robot verify should be attempted");
+    siwe_request_mock.assert_hits(0);
+    siwe_verify_mock.assert_hits(0);
+}
+
+#[tokio::test]
+async fn run_robot_node_cancels_while_initial_dds_authentication_hangs() {
+    let server = MockServer::start();
+    let register_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/robots/register");
+        then.delay(Duration::from_secs(5)).status(503);
+    });
+
+    let cfg = robot_cfg(&server);
+    let shutdown = CancellationToken::new();
+    let run_task = tokio::spawn(run_robot_node_with_shutdown(
+        cfg,
+        support::mock_runner::registry_with_mock(),
+        shutdown.clone(),
+    ));
+
+    let started = Instant::now();
+    while register_mock.hits() == 0 && started.elapsed() < Duration::from_secs(2) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(register_mock.hits(), 1, "robot registration should start");
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_millis(500), run_task)
+        .await
+        .expect("hanging DDS authentication must not delay shutdown")
+        .expect("robot engine task join")
+        .expect("robot engine should shut down cleanly");
+}
+
+#[tokio::test]
+async fn run_robot_node_cancels_while_forced_dds_refresh_hangs() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+
+    let register_mock = server.mock(move |when, then| {
+        when.method(POST).path("/internal/v1/robots/register");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "robot_id": robot_id,
+                "access_token": "robot-token-before-refresh",
+                "access_expires_at": expires_at,
+            }));
+    });
+    let lease_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/tasks")
+            .header("authorization", "Bearer robot-token-before-refresh");
+        then.status(401);
+    });
+    let verify_mock = server.mock(|when, then| {
+        when.method(POST).path("/internal/v1/auth/robot/verify");
+        then.delay(Duration::from_secs(5)).status(503);
+    });
+
+    let cfg = robot_cfg(&server);
+    let shutdown = CancellationToken::new();
+    let run_task = tokio::spawn(run_robot_node_with_shutdown(
+        cfg,
+        support::mock_runner::registry_with_mock(),
+        shutdown.clone(),
+    ));
+
+    let started = Instant::now();
+    while verify_mock.hits() == 0 && started.elapsed() < Duration::from_secs(2) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(register_mock.hits(), 1);
+    assert_eq!(lease_mock.hits(), 1);
+    assert_eq!(verify_mock.hits(), 1, "forced robot refresh should start");
+
+    shutdown.cancel();
+    tokio::time::timeout(Duration::from_millis(500), run_task)
+        .await
+        .expect("hanging forced refresh must not delay robot shutdown")
+        .expect("robot engine task join")
+        .expect("robot engine should shut down cleanly");
+}
+
+struct BlockingRunner {
+    started: Arc<AtomicBool>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl compute_runner_api::Runner for BlockingRunner {
+    fn capability(&self) -> &'static str {
+        "/posemesh/blocking/v1"
+    }
+
+    async fn run(&self, _ctx: compute_runner_api::TaskCtx<'_>) -> anyhow::Result<()> {
+        let release = self.release.notified();
+        self.started.store(true, Ordering::Release);
+        release.await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn run_robot_node_finishes_an_active_lease_before_shutdown() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let task_id = Uuid::new_v4();
+    let domain_id = Uuid::new_v4();
+    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+    let lease_expires_at = (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339();
+
+    let register_mock = server.mock(move |when, then| {
+        when.method(POST).path("/internal/v1/robots/register");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "robot_id": robot_id,
+                "access_token": "robot-active-token",
+                "access_expires_at": expires_at,
+            }));
+    });
+    let lease_mock = server.mock({
+        let base_url = server.base_url();
+        let lease_expires_at = lease_expires_at.clone();
+        move |when, then| {
+            when.method(GET)
+                .path("/tasks")
+                .header("authorization", "Bearer robot-active-token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "access_token": "active-session-token",
+                    "lease_expires_at": lease_expires_at,
+                    "domain_id": domain_id,
+                    "domain_server_url": base_url,
+                    "task": {
+                        "id": task_id,
+                        "capability": "/posemesh/blocking/v1",
+                        "outputs_prefix": "out"
+                    }
+                }));
+        }
+    });
+    let heartbeat_mock = server.mock({
+        let base_url = server.base_url();
+        move |when, then| {
+            when.method(POST)
+                .path(format!("/tasks/{task_id}/heartbeat"))
+                .header("authorization", "Bearer robot-active-token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "access_token": "active-session-token",
+                    "lease_expires_at": (chrono::Utc::now()
+                        + chrono::Duration::seconds(30))
+                        .to_rfc3339(),
+                    "cancel": false,
+                    "status": "running",
+                    "domain_id": domain_id,
+                    "domain_server_url": base_url,
+                    "task_id": task_id
+                }));
+        }
+    });
+    let complete_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path(format!("/tasks/{task_id}/complete"))
+            .header("authorization", "Bearer robot-active-token");
+        then.status(200);
+    });
+
+    let started = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(Notify::new());
+    let runners = RunnerRegistry::new().register(BlockingRunner {
+        started: started.clone(),
+        release: release.clone(),
+    });
+    let cfg = robot_cfg(&server);
+    let shutdown = CancellationToken::new();
+    let mut run_task = tokio::spawn(run_robot_node_with_shutdown(cfg, runners, shutdown.clone()));
+
+    let wait_started = Instant::now();
+    while !started.load(Ordering::Acquire) && wait_started.elapsed() < Duration::from_secs(2) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        started.load(Ordering::Acquire),
+        "runner should start after a lease is acquired"
+    );
+
+    shutdown.cancel();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), &mut run_task)
+            .await
+            .is_err(),
+        "shutdown must not drop an active leased cycle"
+    );
+    complete_mock.assert_hits(0);
+
+    release.notify_one();
+    tokio::time::timeout(Duration::from_secs(2), run_task)
+        .await
+        .expect("active cycle should finish after the runner is released")
+        .expect("robot engine task join")
+        .expect("robot engine should shut down after completing the lease");
+
+    register_mock.assert_hits(1);
+    lease_mock.assert_hits(1);
+    assert!(heartbeat_mock.hits() >= 1, "heartbeat should remain active");
+    complete_mock.assert_hits(1);
 }

--- a/core/compute-node/tests/engine_dms_flow.rs
+++ b/core/compute-node/tests/engine_dms_flow.rs
@@ -647,7 +647,7 @@ async fn run_robot_node_refreshes_after_dms_401_and_retries_with_machine_token()
 }
 
 #[tokio::test]
-async fn run_robot_node_does_not_fall_back_to_siwe_when_verify_fails() {
+async fn run_robot_node_backs_off_without_siwe_fallback_when_verify_fails() {
     let server = MockServer::start();
     let robot_id = Uuid::new_v4();
     let expires_at = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
@@ -693,6 +693,22 @@ async fn run_robot_node_does_not_fall_back_to_siwe_when_verify_fails() {
     while verify_mock.hits() == 0 && started.elapsed() < Duration::from_secs(3) {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
+    assert_eq!(
+        verify_mock.hits(),
+        1,
+        "robot verify should be attempted once"
+    );
+
+    // The foreground engine used to retry at the one-second poll floor here,
+    // bypassing the token manager's background cooldown and eventually
+    // triggering DDS rate limiting. It must share the same minimum cadence.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    assert_eq!(
+        verify_mock.hits(),
+        1,
+        "robot verify must not repeat before the authentication backoff elapses"
+    );
+
     shutdown.cancel();
     tokio::time::timeout(Duration::from_secs(2), run_task)
         .await
@@ -702,7 +718,7 @@ async fn run_robot_node_does_not_fall_back_to_siwe_when_verify_fails() {
 
     register_mock.assert_hits(1);
     stale_lease_mock.assert_hits(1);
-    assert!(verify_mock.hits() >= 1, "robot verify should be attempted");
+    verify_mock.assert_hits(1);
     siwe_request_mock.assert_hits(0);
     siwe_verify_mock.assert_hits(0);
 }

--- a/core/compute-node/tests/robot_auth.rs
+++ b/core/compute-node/tests/robot_auth.rs
@@ -1,0 +1,231 @@
+use httpmock::prelude::*;
+use posemesh_compute_node::auth::token_manager::{TokenManagerConfig, TokenProvider};
+use posemesh_compute_node::auth::RobotMachineAuth;
+use serde_json::json;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::subscriber;
+use tracing_subscriber::{layer::SubscriberExt, registry};
+use uuid::Uuid;
+
+const REGISTER_PATH: &str = "/internal/v1/robots/register";
+const VERIFY_PATH: &str = "/internal/v1/auth/robot/verify";
+const SIWE_REQUEST_PATH: &str = "/internal/v1/auth/siwe/request";
+const SIWE_VERIFY_PATH: &str = "/internal/v1/auth/siwe/verify";
+
+fn token_config() -> TokenManagerConfig {
+    TokenManagerConfig {
+        safety_ratio: 0.75,
+        max_retries: 0,
+        jitter: Duration::ZERO,
+    }
+}
+
+fn access_response(robot_id: Uuid, token: &str) -> serde_json::Value {
+    json!({
+        "robot_id": robot_id,
+        "access_token": token,
+        "access_expires_at": (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+    })
+}
+
+fn robot_auth(
+    server: &MockServer,
+    credentials: &str,
+    capabilities: Vec<String>,
+) -> RobotMachineAuth {
+    RobotMachineAuth::new(
+        server.base_url().parse().unwrap(),
+        credentials,
+        "1.2.3",
+        capabilities,
+        Duration::from_secs(5),
+        token_config(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn register_payload_is_exact_and_forced_refresh_is_single_flight_verify() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let credentials = "opaque-robot-credentials";
+    let capabilities = vec![
+        "/example/robot/local/v1".to_string(),
+        "/example/robot/global/v1".to_string(),
+    ];
+
+    let register = server.mock(|when, then| {
+        when.method(POST).path(REGISTER_PATH).json_body(json!({
+            "registration_credentials": credentials,
+            "version": "1.2.3",
+            "capabilities": capabilities,
+        }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(access_response(robot_id, "robot-token-a"));
+    });
+    let verify = server.mock(|when, then| {
+        when.method(POST).path(VERIFY_PATH).json_body(json!({
+            "registration_credentials": credentials,
+        }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(access_response(robot_id, "robot-token-b"));
+    });
+
+    let auth = robot_auth(&server, credentials, capabilities);
+    let handle = auth.start().await.expect("robot auth starts");
+    assert_eq!(handle.bearer().await.unwrap(), "robot-token-a");
+    register.assert_hits(1);
+    verify.assert_hits(0);
+
+    handle.on_unauthorized().await;
+    let mut tasks = Vec::new();
+    for _ in 0..16 {
+        let cloned = handle.clone();
+        tasks.push(tokio::spawn(async move { cloned.bearer().await.unwrap() }));
+    }
+    for task in tasks {
+        assert_eq!(task.await.unwrap(), "robot-token-b");
+    }
+
+    register.assert_hits(1);
+    verify.assert_hits(1);
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_fresh_authenticator_registers_again_after_restart() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let credentials = "restart-safe-credentials";
+    let capabilities = vec!["/example/robot/v1".to_string()];
+
+    let register = server.mock(|when, then| {
+        when.method(POST).path(REGISTER_PATH).json_body(json!({
+            "registration_credentials": credentials,
+            "version": "1.2.3",
+            "capabilities": capabilities,
+        }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(access_response(robot_id, "restart-token"));
+    });
+    let verify = server.mock(|when, then| {
+        when.method(POST).path(VERIFY_PATH);
+        then.status(500);
+    });
+
+    let first = robot_auth(&server, credentials, capabilities.clone());
+    let first_handle = first.start().await.expect("first process registers");
+    first.shutdown().await;
+    assert!(
+        first_handle.bearer().await.is_err(),
+        "the owning authenticator must stop handles when it shuts down"
+    );
+
+    let restarted = robot_auth(&server, credentials, capabilities);
+    let restarted_handle = restarted
+        .start()
+        .await
+        .expect("restart registers idempotently");
+    restarted_handle.shutdown().await;
+
+    register.assert_hits(2);
+    verify.assert_hits(0);
+}
+
+#[tokio::test]
+async fn rejected_credentials_fail_closed_without_siwe_or_sensitive_logs() {
+    let server = MockServer::start();
+    let robot_id = Uuid::new_v4();
+    let credentials = "rotated-or-revoked-robot-secret";
+    let issued_token = "sensitive-robot-access-token";
+    let upstream_body = "sensitive-upstream-response-body";
+    let capabilities = vec!["/example/robot/v1".to_string()];
+
+    let register = server.mock(|when, then| {
+        when.method(POST).path(REGISTER_PATH);
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(access_response(robot_id, issued_token));
+    });
+    let verify = server.mock(|when, then| {
+        when.method(POST).path(VERIFY_PATH).json_body(json!({
+            "registration_credentials": credentials,
+        }));
+        then.status(401).body(upstream_body);
+    });
+    let siwe_request = server.mock(|when, then| {
+        when.method(POST).path(SIWE_REQUEST_PATH);
+        then.status(200);
+    });
+    let siwe_verify = server.mock(|when, then| {
+        when.method(POST).path(SIWE_VERIFY_PATH);
+        then.status(200);
+    });
+    let (guard, logs) = capture_logs();
+
+    let auth = robot_auth(&server, credentials, capabilities);
+    let handle = auth.start().await.expect("initial registration succeeds");
+    handle.on_unauthorized().await;
+    let err = handle
+        .bearer()
+        .await
+        .expect_err("rejected credentials must not retain or replace the token");
+    handle.shutdown().await;
+    drop(guard);
+
+    register.assert_hits(1);
+    assert!(verify.hits() >= 1);
+    siwe_request.assert_hits(0);
+    siwe_verify.assert_hits(0);
+
+    let error_text = err.to_string();
+    let captured = String::from_utf8(logs.lock().clone()).unwrap_or_default();
+    for sensitive in [credentials, issued_token, upstream_body] {
+        assert!(!error_text.contains(sensitive));
+        assert!(
+            !captured.contains(sensitive),
+            "robot authentication logs exposed sensitive material"
+        );
+    }
+}
+
+fn capture_logs() -> (
+    tracing::subscriber::DefaultGuard,
+    Arc<parking_lot::Mutex<Vec<u8>>>,
+) {
+    struct BufferWriter(Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl io::Write for BufferWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.0.lock().extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct MakeBufferWriter(Arc<parking_lot::Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeBufferWriter {
+        type Writer = BufferWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            BufferWriter(self.0.clone())
+        }
+    }
+
+    let buffer = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let layer = tracing_subscriber::fmt::layer()
+        .with_writer(MakeBufferWriter(buffer.clone()))
+        .with_ansi(false)
+        .without_time();
+    let guard = subscriber::set_default(registry().with(layer));
+    (guard, buffer)
+}

--- a/core/domain-http/src/auth.rs
+++ b/core/domain-http/src/auth.rs
@@ -350,7 +350,7 @@ impl AuthClient {
 
         let response = self
             .client
-            .post(format!("{}/user/login", &self.api_url))
+            .post(format!("{}/user/login", self.api_url))
             .header("Content-Type", "application/json")
             .header("posemesh-client-id", &self.client_id)
             .json(&credentials)
@@ -397,7 +397,7 @@ impl AuthClient {
     async fn get_dds_token_by_token(&self, token: &str) -> Result<DdsTokenResponse, DomainError> {
         let dds_response = self
             .client
-            .post(format!("{}/service/domains-access-token", &self.api_url))
+            .post(format!("{}/service/domains-access-token", self.api_url))
             .header("Authorization", format!("Bearer {}", token))
             .header("Content-Type", "application/json")
             .header("posemesh-client-id", &self.client_id)


### PR DESCRIPTION
## Summary

- add a separate walletless robot machine-authentication path using opaque DDS registration credentials
- reuse the existing token manager, DMS client, runner, storage, heartbeat, and completion engine
- add an explicit robot hello-runner binary while preserving the current SIWE binary as the default
- harden persistent authentication backoff, shutdown behavior, and sensitive DMS response logging

## Compatibility

- `NodeConfig`, `NodeConfig::from_env`, `run_node`, `run_node_with_shutdown`, legacy registration, SIWE, and the default hello-runner command remain unchanged
- robot mode uses a separate `RobotNodeConfig` and explicit entrypoint; it never requires a wallet/private key and never falls back to SIWE
- machine requests send only DDS-issued registration credentials, version, and advertised capabilities; type, mode, organization, and domain assignment remain server-authoritative
- no dependency or lockfile changes

## Dependencies

Part of aukilabs/robotics_rollout#58.

- depends on aukilabs/domain-manager-service#35
- depends on aukilabs/domain-service#550

## Validation

- `make ci-compute-node`
- `cargo build -p posemesh-hello-runner --all-targets`
- repeated shared SIWE/robot engine-flow coverage
- disposable live DDS + DMS + Domain Server + Posemesh execution:
  - an assigned robot leased a dedicated task, uploaded real output, heartbeated, and completed it
  - public and wrong-domain tasks stayed unclaimed; the receipt remained reward-ignored
  - credential rotation and revocation failed closed, old JWTs stopped working after expiry plus verifier skew, and no SIWE fallback occurred
  - A→B reassignment remained blocked through access-token, task-token, lease, online-TTL, and clock-skew drains, then succeeded with strict A/B isolation
  - clean worker restart recovered without credential rotation
  - DMS and DDS outages kept the worker alive; failed authentication batches were throttled to about 30 seconds, produced no 429 flood, and recovered automatically
  - work submitted while DDS was unavailable remained queued until fresh authentication after recovery
- real API-backed provisioning smoke: API login/token, DDS domain and robot provisioning/assignment, machine registration, DMS claim/heartbeat/complete, and DDS presence projection all passed

All disposable databases, processes, containers, logs, credentials, and signing keys used by the live runs were removed afterward.

## CI note

The robot/Rust suites, Clippy, CodeQL, and CLA pass. The repository-wide unit workflow currently has one unrelated live-dev integration failure: `oidc_access_token > should upload domain data` returns `403 invalid domain access token` (21 sibling tests pass). A rerun reproduced it exactly. The test and workflow are unchanged by this PR; the configured CI OIDC token/domain fixture needs its write authorization refreshed.

The live sequence also exposed two pre-existing DDS/Domain Server recovery issues (same-owner 2-minute re-registration inside DDS's 3-minute grace, and transport failures not being retried). Both fixes and their stock-timer/live-proxy validation are now in the dependent domain-service draft.
